### PR TITLE
Add build:clean script

### DIFF
--- a/packages/cycle-scripts-one-fits-all/scripts/init.js
+++ b/packages/cycle-scripts-one-fits-all/scripts/init.js
@@ -1,4 +1,5 @@
-'use strict'
+,
+    'use strict'
 
 const fs = require('fs-extra')
 const path = require('path')
@@ -18,7 +19,8 @@ const devDependencies = [
     'cyclejs-test-helpers@1.3.0',
     'html-looks-like@1.0.2',
     'jsverify@0.8.2',
-    'snabbdom-to-html@3.1.1'
+    'snabbdom-to-html@3.1.1',
+    'rimraf@2.6.1'
 ];
 
 function patchGitignore (appPath) {
@@ -84,6 +86,7 @@ module.exports = function init (appPath, appName, verbose, originalDirectory) {
         'start': 'cycle-scripts start',
         'test': 'cycle-scripts test',
         'build': 'cycle-scripts build',
+        'build:clean': 'rimraf build .tmp .nyc_output coverage',
         'eject': 'cycle-scripts eject'
     }
 


### PR DESCRIPTION
a `clean` target is a common pattern with tradition makefile and I think is still useful here as removes junk and resets to a know condition..

I decided is simple so I did not make it a flavour script but it could be argued everything should be encapsulated so should be moved. I think eject works fine.